### PR TITLE
fix: support macOS

### DIFF
--- a/console/console.go
+++ b/console/console.go
@@ -52,6 +52,7 @@ func (c *Console) OutputTo(upCnt uint, str string) {
 	fmt.Fprint(c, aec.Restore)
 	fmt.Fprint(c, aec.Up(upCnt))
 	fmt.Fprint(c, aec.Column(0))
+	// fprintf will generate !(NOVERB) for no reason
 	fmt.Fprint(c, str+" ")
 	fmt.Fprint(c, aec.EraseLine(aec.EraseModes.Tail))
 }

--- a/console/console.go
+++ b/console/console.go
@@ -38,18 +38,21 @@ func GetConsole(f *os.File) (*Console, error) {
 
 func (c *Console) Save() {
 	fmt.Fprint(c, aec.Hide)
-	fmt.Fprint(c, aec.Save)
+	fmt.Fprint(c, "\0337")
 }
 
 func (c *Console) NewRow() {
-	fmt.Fprint(c, aec.Restore)
+	// fmt.Fprint(c, aec.Restore)
+	fmt.Fprint(c, "\0338")
 	fmt.Fprint(c, aec.Down(1))
 	fmt.Fprint(c, aec.Column(0))
-	fmt.Fprint(c, aec.Save)
+	fmt.Fprint(c, "\0337")
+	// fmt.Fprint(c, aec.Save)
 }
 
 func (c *Console) OutputTo(upCnt uint, str string) {
-	fmt.Fprint(c, aec.Restore)
+	// fmt.Fprint(c, aec.Restore)
+	fmt.Fprint(c, "\0338")
 	fmt.Fprint(c, aec.Up(upCnt))
 	fmt.Fprint(c, aec.Column(0))
 	// fprintf will generate !(NOVERB) for no reason
@@ -58,7 +61,8 @@ func (c *Console) OutputTo(upCnt uint, str string) {
 }
 
 func (c *Console) Restore() {
-	fmt.Fprint(c, aec.Restore)
+	fmt.Fprint(c, "\0338")
+	// fmt.Fprint(c, aec.Restore)
 	fmt.Fprint(c, aec.Column(0))
 	fmt.Fprint(c, aec.EraseLine(aec.EraseModes.All))
 	fmt.Fprint(c, aec.Show)

--- a/progress/manager.go
+++ b/progress/manager.go
@@ -87,7 +87,7 @@ func (m *manager) render() {
 	}
 
 	for ; offset < len; offset++ {
-		m.c.OutputTo(uint(len-offset), m.statuses[offset].String(width))
+		m.c.OutputTo(uint(len-offset-1), m.statuses[offset].String(width))
 	}
 }
 


### PR DESCRIPTION
The escape sequences for "save cursor position" and "restore cursor position" were never standardize as part of the ANSI (or subsequent) specs, resulting in two different sequences known in some circles as "DEC" and "SCO":

- DEC: ESC7 (save) and ESC8 (restore)
- SCO: ESC[s (save) and ESC[u (restore)

The built-in macOS Terminal.app only supports the DEC sequences.

Fixes #2.