### PR TITLE
fix: remove first empty line

### DIFF
--- a/progress/manager.go
+++ b/progress/manager.go
@@ -87,7 +87,7 @@ func (m *manager) render() {
 	}
 
 	for ; offset < len; offset++ {
-		m.c.OutputTo(uint(len-offset-1), m.statuses[offset].String(width))
+		m.c.OutputTo(uint(len-offset), m.statuses[offset].String(width))
 	}
 }
 


### PR DESCRIPTION
This PR removes an empty line being printed during execution.